### PR TITLE
Fix windows pluigin service bug when no required services are provided

### DIFF
--- a/WinRTBle/src/LibWinRTBle/Peripheral.cpp
+++ b/WinRTBle/src/LibWinRTBle/Peripheral.cpp
@@ -133,7 +133,7 @@ namespace Systemic::BluetoothLE
 
                     auto gattServices = servicesResult.Services();
                     bool hasRequiredServices = requiredServices.size() > 0;
-                    // If no serivces are required, skip checking for missing services
+                    // If no service is required, skip checking for missing services
                     if (hasRequiredServices) {
                         // Iterate through services to make sure we have all the requested ones
                         std::vector<winrt::guid> servicesUuids{};


### PR DESCRIPTION
Don't skip registering services and characteristics, when there are no required services provided in the sgBleConnectPeripheral method call.

(Only the plugin source code is updated, the compiled dll is unchanged)